### PR TITLE
Content fix

### DIFF
--- a/_data/about.yml
+++ b/_data/about.yml
@@ -45,10 +45,8 @@ disclaimer_area:
       text_nodes:
         - node: Using Onion Browser does not guarantee security or privacy on its own. It simply provides a set of features that may enhance privacy and anonymity while browsing the web. Please remember the following...
         - node: Apple requires all web browser apps to use the same core web rendering ending, called UIWebKit or WKWebView. Due to this limitation, we are unable to compile and include our own web engine, based on Firefox Gecko, that other browsers, like Tor Browser on desktop for Android, are allowed to do.
-        - node: Onion Browser only tunnels traffic within the Onion Browser app. If you are using a smartphone be aware that information outside of Onion Browser is not protected.
-        - node: If you use Onion Browser to log into websites that you sometimes log into without Tor (i.e. Facebook), the website will know who you are and know that you are using Tor. In certain circumstances (i.e. political dissents in repressive nations), this may be incriminating.
-        - node: Onion Browser only tunnels traffic within the Onion Browser app. You are still using a smartphone you should be aware that information outside of Onion Browser will continue to use your normal connection.
-        - node: If you log into websites in Onion Browser that you normally log into outside of the Tor network, they will still know who you are and know that you use Tor. In certain circumstances (i.e. political dissent in repressive nations), this may be incriminating information in itself.
+        - node: Onion Browser only tunnels traffic within the Onion Browser app. Please note that network traffic outside of Onion Browser is not protected and will continue to use your normal connection.
+        - node: If you use Onion Browser to log into websites that you normally access outside of the Tor network, the website may be able to identify you and know that you are using Tor. In certain circumstances (e.g. political dissent in repressive nations), this may be incriminating information in itself.
 
     - title: Limitations in iOS
       text_nodes:

--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -18,4 +18,4 @@ faq_items:
     answer: Bridges are Tor relays that help circumvent censorship. You can try bridges if Tor is blocked by your ISP.
 
   - question: What’s the difference between browsing with Tor on iOS and browsing with Tor on my computer?
-    answer: The primary difference is that Apple requires we use the WebKit browser component they provie. With Tor Browser on Desktop and Android, the browser is built upon Mozilla's Firefox / Gecko component, which offers greater control and more reliability when it comes to implementing proxying and anti-tracking techniques.
+    answer: The primary difference is that Apple requires we use the WebKit browser component they provide. With Tor Browser on Desktop and Android, the browser is built upon Mozilla's Firefox / Gecko component, which offers greater control and more reliability when it comes to implementing proxying and anti-tracking techniques.


### PR DESCRIPTION
Consolidates duplicate content on the about page and fixes a typo on the FAQ page. Closes #19.