### PR TITLE
Update "Featured in" links in the home page

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -55,11 +55,11 @@ featured_area:
   featured_area_items:
     - image: /assets/img/NewYorkTimes.png
       alt: NewYorkTimes-logo
-      url: "http://www.nytimes.com/2014/02/20/technology/personaltech/privacy-please-tools-to-shield-your-smartphone-from-snoopers.html"
+      url: "https://www.nytimes.com/2014/02/20/technology/personaltech/privacy-please-tools-to-shield-your-smartphone-from-snoopers.html"
 
     - image: /assets/img/TheGuardian.png
       alt: TheGuardian-logo
-      url: "http://www.guardian.co.uk/technology/appsblog/2012/apr/27/apps-rush-linkedin-frankenstein-o2wallet"
+      url: "https://www.theguardian.com/technology/appsblog/2012/apr/27/apps-rush-linkedin-frankenstein-o2wallet"
 
     - image: /assets/img/ArsTechnica.jpg
       alt: ArsTechnica-logo
@@ -67,19 +67,15 @@ featured_area:
 
     - image: /assets/img/TechCrunch.png
       alt: TechCrunch-logo
-      url: "http://techcrunch.com/2012/04/26/onion-browser-a-mobile-browser-for-the-truly-paranoid/"
+      url: "https://techcrunch.com/2012/04/26/onion-browser-a-mobile-browser-for-the-truly-paranoid/"
 
     - image: /assets/img/BoingBoing.png
       alt: BoingBoing-logo
-      url: "http://boingboing.net/2012/04/26/encrypted-browser-for-ipad-and.html"
+      url: "https://boingboing.net/2012/04/26/encrypted-browser-for-ipad-and.html"
 
     - image: /assets/img/LifeHacker.png
       alt: LifeHacker-logo
-      url: "http://lifehacker.com/5905305/onion-browser-is-an-encrypted-mobile-browser-for-ios"
-
-    - image: /assets/img/Gizmodo.png
-      alt: Gizmodo-logo
-      url: "http://gizmodo.com/5905265/onion-browser-brings-encrypted-web-browsing-to-the-iphone"
+      url: "https://lifehacker.com/onion-browser-is-an-encrypted-mobile-browser-for-ios-5905305"
 
 
 special_area:


### PR DESCRIPTION
Switched old HTTP links to the current HTTPS equivalents and removed the Gizmodo link because it ends at a "404 / Page not found" page in the Gizmodo website.

If you want to reference other articles from other news sources and blogs that talk about the Onion browser, the following are some options I found:

The Tor Project blog:
https://blog.torproject.org/tor-heart-onion-browser-and-more-ios-tor/

WCCF TECH:
https://wccftech.com/official-tor-browser-ios-free-download/

Mac World:
https://www.macworld.com/article/229361/anonymous-browsing-with-tor-reduces-exposure-but-still-has-risks.html

OS X Daily:
https://osxdaily.com/2017/08/12/use-tor-iphone-ipad-onion-browser/

iDevice.ro:
https://www.idevice.ro/en/2016/12/02/onion-browser-te-face-anonim-pe-internet-este-disponibil-gratuit/

iPhone in Canada:
https://www.iphoneincanada.ca/2017/01/10/onion-browser-app-store/

Cult of Mac:
https://www.cultofmac.com/163314/the-onion-browser-brings-anonymous-encrypted-browsing-to-ios/

Not exactly blogs or news sources, but maybe still interesting links to consider:

The Tor Project's support page:
https://support.torproject.org/tormobile/tormobile-3/ https://support.torproject.org/glossary/onion-browser/

EFF's surveillance self-defense guide:
https://ssd.eff.org/module/how-to-use-tor-on-android-and-iphone

Hacker news:
https://news.ycombinator.com/item?id=32129186

Privacy Guides:
https://www.privacyguides.org/en/tor/#onion-browser

Techlore resources:
https://www.techlore.tech/resources#ios-browsers